### PR TITLE
Move jshint options to .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+    "curly"         : true,     // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "immed"         : true,     // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "indent"        : 2,        // {int} Number of spaces to use for indentation
+    "latedef"       : true,     // true: Require variables/functions to be defined before being used
+    "newcap"        : true,     // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "quotmark"      : "single", // Quotation mark consistency:
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : true,     // true: Require all defined variables be used
+    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+    "boss"          : true,     // true: Tolerate assignments where comparisons would be expected
+    "eqnull"        : true,     // true: Tolerate use of `== null`
+    "node"          : true      // Node.js
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,22 +6,7 @@ module.exports = function (grunt) {
     grunt.initConfig({
         jshint: {
             options: {
-                'node': true,
-                'curly': true,
-                'eqeqeq': true,
-                'immed': true,
-                'latedef': true,
-                'newcap': true,
-                'noarg': true,
-                'noempty': true,
-                'unused': true,
-                'undef': true,
-                'trailing': true,
-                'indent': 2,
-                'quotmark': 'single',
-                'boss': true,
-                'eqnull': true,
-                'strict': true
+                jshintrc: true,
             },
             node: {
                 files: {


### PR DESCRIPTION
This PR moves JSHint configuration _out_ of `Gruntfile.js` and _into_ `.jshintrc`.

Only previously existing options have been migrated.
